### PR TITLE
Add automatic Firebase build & deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+      - run: npm ci --prefix functions
+      - run: npm run build --prefix functions
+      - run: npm install -g firebase-tools
+      - run: firebase deploy --project autoapi-d4a2d --token $FIREBASE_TOKEN
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "public",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
## Summary
- deploy from `dist` instead of `public`
- add GitHub Actions workflow to build and deploy to Firebase when `main` is updated

## Testing
- `npm run build`
- `npm ci --prefix functions`
- `npm run build --prefix functions`


------
https://chatgpt.com/codex/tasks/task_e_685065149a2c832fb6f3f5033b1bff90