### PR TITLE
Fix local OpenAI key usage

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,7 +13,14 @@ const app = express();
 app.use(cors({ origin: true }));
 app.use(express.json());
 
-const openai = new OpenAI({ apiKey: OPENAI_API_KEY.value() });
+let openaiKey: string | undefined;
+try {
+  openaiKey = OPENAI_API_KEY.value();
+} catch {
+  openaiKey = process.env.OPENAI_API_KEY;
+}
+
+const openai = new OpenAI({ apiKey: openaiKey });
 
 app.get('/', (req: Request, res: Response) => {
   res.send('AutoAPI backend');


### PR DESCRIPTION
## Summary
- handle missing OPENAI_API_KEY when running locally

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685080c3df18832fbea0ec9c8b638f8c